### PR TITLE
Generate README command docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ More ways to [contact](https://oorja.io/contact).
 
 
 # Commands
-<!-- commands-disabled -->
+<!-- commands -->
 * [`oorja help [COMMAND]`](#oorja-help-command)
-* [`oorja teletype [SPACE]`](#oorja-teletype-space)
 * [`oorja signout`](#oorja-signout)
+* [`oorja teletype [STREAMKEY]`](#oorja-teletype-streamkey)
 
 ## `oorja help [COMMAND]`
 
@@ -74,45 +74,13 @@ USAGE
   $ oorja help [COMMAND...] [-n]
 
 ARGUMENTS
-  COMMAND...  Command to show help for.
+  [COMMAND...]  Command to show help for.
 
 FLAGS
   -n, --nested-commands  Include all nested commands in the output.
 
 DESCRIPTION
   Display help for oorja.
-```
-
-## `oorja teletype [STREAM_KEY]`
-
-Launch a terminal streaming session in oorja.
-
-```
-USAGE
-  $ oorja teletype [STREAM_KEY] [-h] [-s <value>] [-m] [-n]
-
-FLAGS
-  -h, --help           Show CLI help.
-  -m, --multiplex      Allows users to WRITE TO YOUR SHELL i.e enables collaboration mode. Make sure you trust space
-                       participants. Off by default
-  -n, --new_space      Create new space
-  -s, --shell=<value>  [default: /usr/bin/bash] shell to use. e.g. bash, fish
-
-DESCRIPTION
-  Launch a terminal streaming session in oorja.
-
-ALIASES
-  $ oorja tty
-
-EXAMPLES
-  $ teletype
-  Will prompt to choose streaming destination - existing space or create a new one.
-
-  $ teletype $stream-key
-  Will stream to the space specified by secret link.
-
-  $ teletype -m
-  Will also allow participants to write to your terminal!
 ```
 
 ## `oorja signout`
@@ -127,4 +95,36 @@ DESCRIPTION
   Sign-out of oorja. Clears saved auth-token
 ```
 
-<!-- commandsstop-disabled -->
+## `oorja teletype [STREAMKEY]`
+
+Launch a terminal streaming session in oorja.
+
+```
+USAGE
+  $ oorja teletype [STREAMKEY] [-h] [-s <value>] [-m] [-n]
+
+FLAGS
+  -h, --help           Show CLI help.
+  -m, --multiplex      Allows users to WRITE TO YOUR SHELL i.e enables collaboration mode. Make sure you trust space
+                       participants. Off by default
+  -n, --new_space      Create new space
+  -s, --shell=<value>  shell to use. e.g. bash, fish
+
+DESCRIPTION
+  Launch a terminal streaming session in oorja.
+
+ALIASES
+  $ oorja tty
+
+EXAMPLES
+  $ teletype
+  Will prompt to choose streaming destination - either enter a stream key for an existing space or create a new space.
+
+  $ teletype 'sk-xxxx:space-id#encryption-secret'
+  Will stream to the space using the secret stream-key. NOTE: stream-keys are personal (generated for you in the teletype app at oorja.io), do not accept them from other people, nor should
+  you share your stream-keys with others.
+
+  $ teletype -m
+  Will also allow participants to write to your terminal! Collaboration mode must be explicitly enabled.
+```
+<!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -61,39 +61,9 @@ More ways to [contact](https://oorja.io/contact).
 
 # Commands
 <!-- commands -->
-* [`oorja help [COMMAND]`](#oorja-help-command)
-* [`oorja signout`](#oorja-signout)
 * [`oorja teletype [STREAMKEY]`](#oorja-teletype-streamkey)
-
-## `oorja help [COMMAND]`
-
-Display help for oorja.
-
-```
-USAGE
-  $ oorja help [COMMAND...] [-n]
-
-ARGUMENTS
-  [COMMAND...]  Command to show help for.
-
-FLAGS
-  -n, --nested-commands  Include all nested commands in the output.
-
-DESCRIPTION
-  Display help for oorja.
-```
-
-## `oorja signout`
-
-Sign-out of oorja. Clears saved auth-token
-
-```
-USAGE
-  $ oorja signout
-
-DESCRIPTION
-  Sign-out of oorja. Clears saved auth-token
-```
+* [`oorja signout`](#oorja-signout)
+* [`oorja help [COMMAND]`](#oorja-help-command)
 
 ## `oorja teletype [STREAMKEY]`
 
@@ -127,4 +97,36 @@ EXAMPLES
   $ teletype -m
   Will also allow participants to write to your terminal! Collaboration mode must be explicitly enabled.
 ```
+
+## `oorja signout`
+
+Sign-out of oorja. Clears saved auth-token
+
+```
+USAGE
+  $ oorja signout
+
+DESCRIPTION
+  Sign-out of oorja. Clears saved auth-token
+```
+
+
+## `oorja help [COMMAND]`
+
+Display help for oorja.
+
+```
+USAGE
+  $ oorja help [COMMAND...] [-n]
+
+ARGUMENTS
+  [COMMAND...]  Command to show help for.
+
+FLAGS
+  -n, --nested-commands  Include all nested commands in the output.
+
+DESCRIPTION
+  Display help for oorja.
+```
+
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -38,16 +38,21 @@
   ],
   "scripts": {
     "build": "shx rm -rf dist && tsc -b",
+    "docs:commands": "pnpm run build && pnpm run docs:commands:generate",
+    "docs:commands:generate": "oclif readme --no-aliases --no-source-links",
     "lint": "eslint . --ext .ts",
-    "prepack": "pnpm run build && oclif manifest && oclif readme",
+    "prepack": "pnpm run build && oclif manifest && pnpm run docs:commands:generate",
     "prepare": "pnpm run build",
-    "version": "oclif readme && git add README.md",
+    "version": "pnpm run docs:commands && git add README.md",
     "format": "prettier --write ."
   },
   "oclif": {
     "bin": "oorja",
     "commands": "./dist/commands",
-    "dirname": "oorja"
+    "dirname": "oorja",
+    "plugins": [
+      "@oclif/plugin-help"
+    ]
   },
   "dependencies": {
     "@msgpack/msgpack": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "shx rm -rf dist && tsc -b",
     "docs:commands": "pnpm run build && pnpm run docs:commands:generate",
-    "docs:commands:generate": "oclif readme --no-aliases --no-source-links",
+    "docs:commands:generate": "oclif readme --no-aliases --no-source-links && node scripts/order-readme-commands.mjs",
     "lint": "eslint . --ext .ts",
     "prepack": "pnpm run build && oclif manifest && pnpm run docs:commands:generate",
     "prepare": "pnpm run build",

--- a/scripts/order-readme-commands.mjs
+++ b/scripts/order-readme-commands.mjs
@@ -1,0 +1,57 @@
+import {readFileSync, writeFileSync} from 'node:fs'
+
+const readmePath = new URL('../README.md', import.meta.url)
+const commandOrder = ['oorja teletype [STREAMKEY]', 'oorja signout', 'oorja help [COMMAND]']
+
+const rank = (command) => {
+  const index = commandOrder.indexOf(command)
+  return index === -1 ? commandOrder.length : index
+}
+
+const sortByCommandOrder = (items, getCommand) =>
+  items
+    .map((item, index) => ({index, item}))
+    .sort((left, right) => rank(getCommand(left.item)) - rank(getCommand(right.item)) || left.index - right.index)
+    .map(({item}) => item)
+
+const between = (text, start, stop) => {
+  const startIndex = text.indexOf(start)
+  const stopIndex = text.indexOf(stop)
+  if (startIndex === -1 || stopIndex === -1 || stopIndex < startIndex) {
+    throw new Error(`Could not find ${start} block in README.md`)
+  }
+
+  return {
+    before: text.slice(0, startIndex + start.length),
+    body: text.slice(startIndex + start.length, stopIndex),
+    after: text.slice(stopIndex),
+  }
+}
+
+const readme = readFileSync(readmePath, 'utf8')
+
+const commands = between(readme, '<!-- commands -->', '<!-- commandsstop -->')
+const commandsBody = commands.body.trim()
+const firstCommandSection = commandsBody.indexOf('\n## `')
+
+if (firstCommandSection === -1) {
+  throw new Error('Could not find generated command sections in README.md')
+}
+
+const tocItems = commandsBody
+  .slice(0, firstCommandSection)
+  .trim()
+  .split('\n')
+  .filter(Boolean)
+
+const sortedTocItems = sortByCommandOrder(tocItems, (item) => item.match(/\[`([^`]+)`\]/)?.[1] ?? '')
+const commandBlocks = commandsBody
+  .slice(firstCommandSection)
+  .trim()
+  .split(/\n(?=## `)/)
+  .filter(Boolean)
+
+const sortedCommandBlocks = sortByCommandOrder(commandBlocks, (block) => block.match(/^## `([^`]+)`/)?.[1] ?? '')
+const orderedReadme = `${commands.before}\n${sortedTocItems.join('\n')}\n\n${sortedCommandBlocks.join('\n\n')}\n${commands.after}`
+
+writeFileSync(readmePath, orderedReadme, 'utf8')

--- a/src/commands/teletype/index.ts
+++ b/src/commands/teletype/index.ts
@@ -38,7 +38,6 @@ Will also allow participants to write to your terminal! Collaboration mode must 
     shell: Flags.string({
       char: 's',
       description: 'shell to use. e.g. bash, fish',
-      default: DEFAULT_SHELL,
     }),
     multiplex: Flags.boolean({
       char: 'm',
@@ -60,8 +59,9 @@ Will also allow participants to write to your terminal! Collaboration mode must 
   async run() {
     const {
       args,
-      flags: {shell, multiplex, new_space},
+      flags: {shell: selectedShell, multiplex, new_space},
     } = await this.parse(TeleTypeCommand)
+    const shell = selectedShell || DEFAULT_SHELL
 
     const config = new Config(this.config.configDir)
     const app = new App(config)


### PR DESCRIPTION
## Summary

- Enables the oclif-managed README command block while leaving custom README content outside the generated tags
- Adds `docs:commands` scripts so command docs can be regenerated intentionally
- Uses `--no-aliases --no-source-links` to keep the README command section compact
- Registers `@oclif/plugin-help` so the generated command section includes `help`
- Keeps the shell default out of generated docs to avoid machine-specific README churn

This is stacked on #18.

## Verification

- pnpm run docs:commands
- pnpm run lint
- pnpm run build
- node bin/run.js --help
- node bin/run.js help
- pnpm pack --pack-destination .tmp-readme-pack
- npm install -g --prefix .tmp-readme-pack/global <packed tarball>
- .tmp-readme-pack/global/bin/teletype --help
- .tmp-readme-pack/global/bin/oorja help