### PR TITLE
Prefer --new for new teletype spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ FLAGS
   -h, --help           Show CLI help.
   -m, --multiplex      Allows users to WRITE TO YOUR SHELL i.e enables collaboration mode. Make sure you trust space
                        participants. Off by default
-  -n, --new_space      Create new space
+  -n, --new            Create a new space
   -s, --shell=<value>  shell to use. e.g. bash, fish
 
 DESCRIPTION

--- a/src/commands/teletype/index.ts
+++ b/src/commands/teletype/index.ts
@@ -45,9 +45,11 @@ Will also allow participants to write to your terminal! Collaboration mode must 
         'Allows users to WRITE TO YOUR SHELL i.e enables collaboration mode. Make sure you trust space participants. Off by default',
       default: false,
     }),
-    new_space: Flags.boolean({
+    new: Flags.boolean({
+      aliases: ['new-space', 'new_space'],
       char: 'n',
-      description: 'Create new space',
+      deprecateAliases: true,
+      description: 'Create a new space',
       default: false,
     }),
   }
@@ -59,7 +61,7 @@ Will also allow participants to write to your terminal! Collaboration mode must 
   async run() {
     const {
       args,
-      flags: {shell: selectedShell, multiplex, new_space},
+      flags: {shell: selectedShell, multiplex, new: createNewSpace},
     } = await this.parse(TeleTypeCommand)
     const shell = selectedShell || DEFAULT_SHELL
 
@@ -70,7 +72,7 @@ Will also allow participants to write to your terminal! Collaboration mode must 
       await this.streamUsingStreamKey(app, {shell, multiplex, streamKey: args.streamKey})
       exit(0)
     }
-    if (new_space) {
+    if (createNewSpace) {
       await this.createRoomAndStream(app, {shell, multiplex})
       exit(0)
     }


### PR DESCRIPTION
## Summary

- Makes `--new` the canonical flag for creating a new teletype space
- Keeps `--new-space` and `--new_space` as deprecated aliases
- Regenerates the README command docs so help shows `-n, --new`

This is stacked on #19.

## Verification

- pnpm run docs:commands
- pnpm run lint
- pnpm run build
- node bin/run.js teletype --help
- node bin/run.js teletype --new-space --help
- node bin/run.js teletype --new_space --help
- pnpm pack --pack-destination .tmp-flag-pack
- npm install -g --prefix .tmp-flag-pack/global <packed tarball>
- .tmp-flag-pack/global/bin/teletype --help