### PR TITLE
Allow SupaKit to provide Teletype auth env

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -6,6 +6,16 @@ export const CLI_VERSION = 2.9
 
 export type env = 'local' | 'prod'
 
+export const SUPAKIT_ACCESS_TOKEN_ENV = 'SUPAKIT_ACCESS_TOKEN'
+export const SUPAKIT_ENV_ENV = 'SUPAKIT_ENV'
+
+const envFromValue = (value: string | undefined): env | undefined => {
+  if (value === 'local' || value === 'prod') {
+    return value
+  }
+  return undefined
+}
+
 export class Config {
   streamKeyAuth: boolean = false
 
@@ -44,11 +54,18 @@ export class Config {
   }
 
   getEnv = (): env => {
-    return this.config['env'] || ('prod' as env)
+    return envFromValue(process.env[SUPAKIT_ENV_ENV]) || envFromValue(this.config['env']) || 'prod'
   }
 
   getAccessToken = () => {
+    if (process.env[SUPAKIT_ACCESS_TOKEN_ENV]) {
+      return process.env[SUPAKIT_ACCESS_TOKEN_ENV]
+    }
     return (this.config[`${this.getEnv()}-access-token`] as string) || ''
+  }
+
+  hasInjectedAccessToken = () => {
+    return Boolean(process.env[SUPAKIT_ACCESS_TOKEN_ENV])
   }
 
   setAccessToken = (token: string) => {

--- a/src/lib/oorja/index.ts
+++ b/src/lib/oorja/index.ts
@@ -121,12 +121,13 @@ export class App {
     spinner.succeed('Online')
 
     const oorjaConfig = getoorjaConfig(this.config.getEnv())
+    const isControlledMode = this.config.hasInjectedAccessToken()
 
     let user: UserProfile | undefined = undefined
 
     try {
       if (!streamKey) {
-        user = await this.tryResumeSession()
+        user = await this.tryResumeSession(isControlledMode)
         if (!user) {
           const token = await promptAuth(this.connectClient!, linkForTokenGen(oorjaConfig))
           if (!token) {
@@ -150,10 +151,16 @@ export class App {
         user = await this.connectClient?.fetchSessionUser(true)
       }
     } catch (e) {
-      this.config.setAccessToken('')
+      if (!isControlledMode) {
+        this.config.setAccessToken('')
+      }
       if (e instanceof Unauthorized) {
         spinner.fail()
-        printExitMessage('Your access token failed authentication, resetting...')
+        printExitMessage(
+          isControlledMode
+            ? 'The provided access token failed authentication.'
+            : 'Your access token failed authentication, resetting...',
+        )
         exit(33)
         return Promise.reject()
       } else {
@@ -185,13 +192,16 @@ export class App {
     }
   }
 
-  private tryResumeSession = async (): Promise<UserProfile | undefined> => {
+  private tryResumeSession = async (isControlledMode: boolean): Promise<UserProfile | undefined> => {
     const personalAccessToken = this.config.getAccessToken()
     if (!personalAccessToken) return
     try {
       return await this.connectClient!.fetchSessionUser()
     } catch (e) {
       if (e instanceof Unauthorized) {
+        if (isControlledMode) {
+          throw e
+        }
         this.config.setAccessToken('') // reset
         return
       }


### PR DESCRIPTION
## Summary
- let SupaKit provide Teletype auth through SUPAKIT_ACCESS_TOKEN
- let SupaKit select the Teletype environment through SUPAKIT_ENV
- keep existing Teletype config behavior as the fallback
- compute controlled mode once in App.init and treat injected auth as authoritative, so invalid injected tokens fail cleanly instead of falling back to the interactive auth prompt

## Verification
- PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm run lint
- PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm run build
- local SupaKit e2e: supakit teletype --new launches local Teletype with injected env auth and fails an invalid token without prompting
