### PR TITLE
Support anonymous Teletype streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Launch a terminal streaming session in SupaKit.
 
 ```
 USAGE
-  $ oorja teletype [STREAMKEY] [-h] [-s <value>] [-m] [-n]
+  $ oorja teletype [STREAMKEY] [-h] [-s <value>] [-m] [-n] [--anonymous] [--ci-debug]
 
 FLAGS
   -h, --help           Show CLI help.
@@ -79,6 +79,8 @@ FLAGS
                        participants. Off by default
   -n, --new            Create a new space
   -s, --shell=<value>  shell to use. e.g. bash, fish
+      --anonymous      Create an anonymous session without prompting for sign-in.
+      --ci-debug       Create a new anonymous writable bash stream for CI debugging.
 
 DESCRIPTION
   Launch a terminal streaming session in SupaKit.
@@ -96,6 +98,9 @@ EXAMPLES
 
   $ teletype -m
   Will also allow participants to write to your terminal! Collaboration mode must be explicitly enabled.
+
+  $ teletype --ci-debug
+  Creates a new anonymous stream without prompting for sign-in. Useful for CI debug sessions you want to control from the link.
 ```
 
 ## `oorja signout`

--- a/src/commands/teletype/index.ts
+++ b/src/commands/teletype/index.ts
@@ -31,6 +31,10 @@ you share your stream-keys with others.
 Will also allow participants to write to your terminal! Collaboration mode must be explicitly enabled.
 
 `,
+    `${chalk.blueBright('$ teletype --ci-debug')}
+Creates a new anonymous stream without prompting for sign-in. Useful for CI debug sessions you want to control from the link.
+
+`,
   ]
 
   static flags = {
@@ -52,6 +56,15 @@ Will also allow participants to write to your terminal! Collaboration mode must 
       description: 'Create a new space',
       default: false,
     }),
+    anonymous: Flags.boolean({
+      description: 'Create an anonymous session without prompting for sign-in.',
+      default: false,
+    }),
+    'ci-debug': Flags.boolean({
+      aliases: ['ci'],
+      description: 'Create a new anonymous writable bash stream for CI debugging.',
+      default: false,
+    }),
   }
 
   static args = {
@@ -61,19 +74,22 @@ Will also allow participants to write to your terminal! Collaboration mode must 
   async run() {
     const {
       args,
-      flags: {shell: selectedShell, multiplex, new: createNewSpace},
+      flags: {shell: selectedShell, multiplex, new: createNewSpace, anonymous, 'ci-debug': ciDebug},
     } = await this.parse(TeleTypeCommand)
-    const shell = selectedShell || DEFAULT_SHELL
+    const shell = selectedShell || (ciDebug ? 'bash' : DEFAULT_SHELL)
+    const shouldCreateNewSpace = createNewSpace || ciDebug
+    const shouldUseAnonymousAuth = anonymous || ciDebug
+    const shouldMultiplex = multiplex || ciDebug
 
     const config = new Config(this.config.configDir)
     const app = new App(config)
 
     if (args.streamKey) {
-      await this.streamUsingStreamKey(app, {shell, multiplex, streamKey: args.streamKey})
+      await this.streamUsingStreamKey(app, {shell, multiplex: shouldMultiplex, streamKey: args.streamKey})
       exit(0)
     }
-    if (createNewSpace) {
-      await this.createRoomAndStream(app, {shell, multiplex})
+    if (shouldCreateNewSpace) {
+      await this.createRoomAndStream(app, {shell, multiplex: shouldMultiplex, anonymous: shouldUseAnonymousAuth})
       exit(0)
     }
 
@@ -93,10 +109,10 @@ Will also allow participants to write to your terminal! Collaboration mode must 
     ])
     switch (answer) {
       case STREAM_USING_STREAM_KEY:
-        await this.streamUsingStreamKey(app, {shell, multiplex})
+        await this.streamUsingStreamKey(app, {shell, multiplex: shouldMultiplex})
         break
       case STREAM_TO_NEW_SPACE:
-        await this.createRoomAndStream(app, {shell, multiplex})
+        await this.createRoomAndStream(app, {shell, multiplex: shouldMultiplex, anonymous: shouldUseAnonymousAuth})
         break
     }
     exit(0)
@@ -109,14 +125,17 @@ Will also allow participants to write to your terminal! Collaboration mode must 
       exit()
     }
     const streamKeyStruct = parseStreamKey(streamKey)
-    const oorja = await app.init(streamKeyStruct)
+    const oorja = await app.init({streamKey: streamKeyStruct})
     const roomKey = oorja.getRoomKey(streamKeyStruct)
     this.clearstdin()
     await oorja.teletype({roomKey, ...options, process})
   }
 
-  private async createRoomAndStream(app: App, {shell, multiplex}: {shell: string; multiplex: boolean}) {
-    const oorja = await app.init()
+  private async createRoomAndStream(
+    app: App,
+    {shell, multiplex, anonymous}: {shell: string; multiplex: boolean; anonymous: boolean},
+  ) {
+    const oorja = await app.init({authMode: anonymous ? 'anonymous' : 'prompt'})
     const spinner = ora({
       text: chalk.bold('Creating space with TeleType app'),
       discardStdin: false,
@@ -149,6 +168,9 @@ Will also allow participants to write to your terminal! Collaboration mode must 
 
     const link = oorja.linkForRoom(roomKey, inviteCode)
     console.log(`\n${chalk.bold(chalk.blueBright(link))}\n`)
+    if (anonymous && multiplex) {
+      console.log(chalk.yellowBright('Anyone with this link can access and write to this shell. Share it carefully.'))
+    }
     console.log(chalk.bold("^^ You'll be streaming here ^^"))
     this.clearstdin()
     return await oorja.teletype({roomKey, shell, multiplex, process})

--- a/src/lib/oorja/index.ts
+++ b/src/lib/oorja/index.ts
@@ -3,7 +3,7 @@ import {RoomKey, UserProfile} from 'oorja/lib/connect/types'
 import {TeletypeSession, TeletypeOptions} from 'oorja/lib/teletype/index'
 import {CreateRoomOptions, ConnectClient} from 'oorja/lib/connect/index'
 import {importKey, createRoomKey, exportKey} from 'oorja/lib/encryption'
-import {promptAuth, validateCliVersion} from 'oorja/lib/oorja/preflight'
+import {createAnonymousSession, promptAuth, validateCliVersion} from 'oorja/lib/oorja/preflight'
 import {getRegion} from 'oorja/lib/oorja/client'
 import ora from 'ora'
 import {Future, printExitMessage} from 'oorja/lib/utils'
@@ -12,6 +12,13 @@ import {exit} from 'oorja/lib/exit'
 import chalk from 'chalk'
 
 export class InvalidRoomLink extends Error {}
+
+export type AuthMode = 'prompt' | 'anonymous'
+
+type AppInitOptions = {
+  streamKey?: StreamKey
+  authMode?: AuthMode
+}
 
 export class OORJA {
   // should capture domain related commands and queries
@@ -105,7 +112,8 @@ export class App {
     this.connectionCheckFuture = new Future()
   }
 
-  init = async (streamKey?: StreamKey): Promise<OORJA> => {
+  init = async (options: AppInitOptions = {}): Promise<OORJA> => {
+    const {streamKey} = options
     let spinner = ora({
       text: 'Checking connectivity..',
       discardStdin: true,
@@ -121,15 +129,19 @@ export class App {
     spinner.succeed('Online')
 
     const oorjaConfig = getoorjaConfig(this.config.getEnv())
-    const isControlledMode = this.config.hasInjectedAccessToken()
+    const authMode = options.authMode || 'prompt'
+    const isControlledMode = authMode !== 'anonymous' && this.config.hasInjectedAccessToken()
 
     let user: UserProfile | undefined = undefined
 
     try {
       if (!streamKey) {
-        user = await this.tryResumeSession(isControlledMode)
+        user = authMode === 'anonymous' ? undefined : await this.tryResumeSession(isControlledMode)
         if (!user) {
-          const token = await promptAuth(this.connectClient!, linkForTokenGen(oorjaConfig))
+          const token =
+            authMode === 'anonymous'
+              ? await createAnonymousSession(this.connectClient!)
+              : await promptAuth(this.connectClient!, linkForTokenGen(oorjaConfig))
           if (!token) {
             printExitMessage('Token not provided :(')
             exit(12)

--- a/src/lib/oorja/preflight.ts
+++ b/src/lib/oorja/preflight.ts
@@ -17,6 +17,12 @@ const promptToken = (): Promise<string> =>
     ])
     .then((answers) => answers.accessToken)
 
+export const createAnonymousSession = async (connectClient: ConnectClient): Promise<string> => {
+  console.log('Creating anonymous user...')
+  connectClient.setAccessToken('')
+  return connectClient.createAnonymousUser()
+}
+
 export const promptAuth = async (connectClient: ConnectClient, generateTokenLink: string): Promise<string> => {
   const ANON = 'Proceed as an anonymous user'
   const SIGN_IN = 'Sign in with SupaKit'
@@ -35,8 +41,7 @@ export const promptAuth = async (connectClient: ConnectClient, generateTokenLink
   ])
   switch (answer) {
     case ANON:
-      console.log('Creating anonymous user...')
-      return connectClient.createAnonymousUser()
+      return createAnonymousSession(connectClient)
     case SIGN_IN:
       console.log(`You can sign-in and generate your token here: ${chalk.blue(generateTokenLink)}`)
       return promptToken()

--- a/src/lib/teletype/index.ts
+++ b/src/lib/teletype/index.ts
@@ -140,18 +140,22 @@ export class TeletypeSession {
       this.resolve?.(null)
     })
 
-    stdin.setEncoding('utf8')
-    stdin.setRawMode!(true)
-
+    const shouldReadLocalStdin = stdin.isTTY && typeof stdin.setRawMode === 'function'
     const stdinDataHandler = (d: Buffer | string) => this.term.write(d.toString('utf8'))
-    stdin.on('data', stdinDataHandler)
+    if (shouldReadLocalStdin) {
+      stdin.setEncoding('utf8')
+      stdin.setRawMode(true)
+      stdin.on('data', stdinDataHandler)
+    }
 
     this.cleanupShell = ({killTerm = true}: {killTerm?: boolean} = {}) => {
       clearInterval(dimensionPoll)
       ptyDataSubscription.dispose()
       ptyExitSubscription.dispose()
-      stdin.off('data', stdinDataHandler)
-      stdin.setRawMode!(false)
+      if (shouldReadLocalStdin) {
+        stdin.off('data', stdinDataHandler)
+        stdin.setRawMode(false)
+      }
       if (killTerm) {
         this.term.kill()
       }


### PR DESCRIPTION
## Summary
- add --anonymous for creating a Teletype session without the auth prompt
- add --ci-debug / --ci shorthand for a new anonymous writable bash stream for CI debugging
- force anonymous mode to skip saved/injected auth and clear the request token before creating the anonymous session
- tolerate non-TTY stdin so CI jobs can run a blocking stream command without crashing on setRawMode
- warn that anyone with the anonymous writable share link can access and write to the shell
- document the CI debug command: teletype --ci-debug

## Verification
- PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm run lint
- PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm run build
- PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm run docs:commands
- teletype --help shows --anonymous, --ci-debug, and the CI debug example
- direct e2e: teletype --ci-debug creates an anonymous stream, prints the link and warning, starts bash, and blocks until timeout
- SupaKit proxy e2e: supakit teletype --ci-debug passes through, creates an anonymous stream, prints the link, starts bash, and blocks until timeout
