### PR TITLE
Fix CI Teletype sizing and prompt handling

### DIFF
--- a/src/lib/teletype/auxiliary.ts
+++ b/src/lib/teletype/auxiliary.ts
@@ -2,6 +2,8 @@ import chalk from 'chalk'
 import termSize from 'terminal-size'
 import {IPty} from 'node-pty'
 
+export const DEFAULT_DIMENSIONS: dimensions = {rows: 24, cols: 80}
+
 export const initScreen = (username: string, hostname: string, shell: string, multiplexed: boolean) => {
   console.log(chalk.bold(chalk.blueBright('TeleType')))
 
@@ -22,6 +24,9 @@ export type dimensions = {
 
 export const getDimensions = (): dimensions => {
   const {rows, columns} = termSize()
+  if (!Number.isFinite(rows) || !Number.isFinite(columns) || rows < 1 || columns < 1) {
+    return DEFAULT_DIMENSIONS
+  }
   return {rows, cols: columns}
 }
 
@@ -35,6 +40,9 @@ export const resizeBestFit = (
   shouldClearScreen: boolean = false,
 ) => {
   const allViewports = Object.values(userDimensions)
+  if (allViewports.length === 0) {
+    return
+  }
   const minrows = Math.min(...allViewports.map((d) => d.rows))
   const mincols = Math.min(...allViewports.map((d) => d.cols))
   term.resize(mincols, minrows)

--- a/src/lib/teletype/index.ts
+++ b/src/lib/teletype/index.ts
@@ -1,7 +1,14 @@
 import {spawn, IPty} from 'node-pty'
 import * as os from 'os'
 import {RoomKey} from 'oorja/lib/connect/types'
-import {getDimensions, dimensions, initScreen, areDimensionEqual, resizeBestFit} from 'oorja/lib/teletype/auxiliary'
+import {
+  DEFAULT_DIMENSIONS,
+  getDimensions,
+  dimensions,
+  initScreen,
+  areDimensionEqual,
+  resizeBestFit,
+} from 'oorja/lib/teletype/auxiliary'
 import chalk from 'chalk'
 import {Unauthorized} from 'oorja/lib/connect/errors'
 import {encrypt, decrypt} from 'oorja/lib/encryption'
@@ -36,9 +43,7 @@ const SELF = 'self'
 export class TeletypeSession {
   private readonly username = os.userInfo().username
   private readonly hostname = os.hostname()
-  private readonly userDimensions: Record<string, dimensions> = {
-    [SELF]: getDimensions(),
-  }
+  private readonly userDimensions: Record<string, dimensions> = {}
 
   private channel!: Channel
   private term!: IPty
@@ -72,7 +77,11 @@ export class TeletypeSession {
 
   private startTerm = () => {
     const {stdin, stdout} = this.options.process
-    const dimensions = this.userDimensions[SELF]
+    const shouldReadLocalStdin = stdin.isTTY && typeof stdin.setRawMode === 'function'
+    const dimensions = shouldReadLocalStdin ? getDimensions() : DEFAULT_DIMENSIONS
+    if (shouldReadLocalStdin) {
+      this.userDimensions[SELF] = dimensions
+    }
 
     console.log(
       chalk.blue(
@@ -92,6 +101,9 @@ export class TeletypeSession {
 
     this.ptyFuture.promise.then(() => {
       initScreen(this.username, this.hostname, this.options.shell, this.options.multiplex)
+      if (!shouldReadLocalStdin) {
+        return
+      }
       if (this.options.shell.endsWith('bash')) {
         stdout.write('Adjusting shell prompt to show streaming indicator\n')
         this.term.write("export PS1='📡 [streaming] '$PS1\n")
@@ -140,7 +152,6 @@ export class TeletypeSession {
       this.resolve?.(null)
     })
 
-    const shouldReadLocalStdin = stdin.isTTY && typeof stdin.setRawMode === 'function'
     const stdinDataHandler = (d: Buffer | string) => this.term.write(d.toString('utf8'))
     if (shouldReadLocalStdin) {
       stdin.setEncoding('utf8')
@@ -163,6 +174,9 @@ export class TeletypeSession {
   }
 
   private reEvaluateOwnDimensions = () => {
+    if (!this.userDimensions[SELF]) {
+      return
+    }
     const lastKnown = this.userDimensions[SELF]
     const latest = getDimensions()
 


### PR DESCRIPTION
## Summary
- do not count the CI runner/non-TTY process as a viewer when calculating best-fit terminal dimensions
- use a safe 80x24 initial PTY size when local terminal dimensions are unavailable
- skip prompt rewriting when there is no local TTY, avoiding PS1 corruption in CI debug streams
- keep browser-reported dimensions as the source of truth once viewers connect

## Verification
- PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm run lint
- PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm run build
- teletype --ci-debug creates a stream, prints the link, starts bash, and no longer writes the prompt-adjustment command in non-TTY mode
